### PR TITLE
fix: use wrapping_add in handle_relative_branch

### DIFF
--- a/src/arch/x86/trampoline/mod.rs
+++ b/src/arch/x86/trampoline/mod.rs
@@ -177,7 +177,7 @@ impl Builder {
                                      -> Result<Box<pic::Thunkable>> {
         // Calculate the absolute address of the target destination
         let destination_address_abs = instruction.next_instruction_address()
-                                    + displacement as usize;
+            .wrapping_add(displacement as usize);
 
         if instruction.is_call() {
             // Calls are not an issue since they return to the original address


### PR DESCRIPTION
Displacement can be negative in some cases, and this fixes the overflow panic from rust.