### PR TITLE
Update static_detours to support "thiscall" convention

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(feature = "nightly", feature(const_fn, unboxed_closures, abi_thiscall))]
-#![cfg_attr(all(feature = "nightly", test), feature(naked_functions, core_intrinsics, asm, abi_thiscall))]
+#![cfg_attr(all(feature = "nightly", test), feature(naked_functions, core_intrinsics, asm))]
 
 //! A cross-platform detour library written in Rust.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "1024"]
-#![cfg_attr(feature = "nightly", feature(const_fn, unboxed_closures))]
-#![cfg_attr(all(feature = "nightly", test), feature(naked_functions, core_intrinsics, asm))]
+#![cfg_attr(feature = "nightly", feature(const_fn, unboxed_closures, abi_thiscall))]
+#![cfg_attr(all(feature = "nightly", test), feature(naked_functions, core_intrinsics, asm, abi_thiscall))]
 
 //! A cross-platform detour library written in Rust.
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -210,6 +210,7 @@ macro_rules! impl_hookable {
         impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "win64"    fn($($ty),*) -> Ret));
         impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "C"        fn($($ty),*) -> Ret));
         impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "system"   fn($($ty),*) -> Ret));
+        impl_hookable!(@impl_pair ($($nm : $ty),*) (extern "thiscall" fn($($ty),*) -> Ret));
     };
 
     (@impl_pair ($($nm:ident : $ty:ident),*) ($($fn_t:tt)*)) => {


### PR DESCRIPTION
Needed to do some detours on class methods, so added support for the `thiscall` convention.