### PR TITLE
Remove obsolete const_fn feature gate on nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(
   feature = "nightly",
-  feature(const_fn, const_fn_trait_bound, unboxed_closures, abi_thiscall)
+  feature(const_fn_trait_bound, unboxed_closures, abi_thiscall)
 )]
 #![cfg_attr(
   all(feature = "nightly", test),


### PR DESCRIPTION
`const_fn` feature flag was removed in PRs rust-lang/rust#85109 and rust-lang/rust#85125. The presence of the flag breaks compatibility with recent nightlies. The flag was removed from the compiler as it is no longer checked by any of the related code.

Fixed #21