### PR TITLE
Fix compiling on nightly

### DIFF
--- a/src/detours/statik.rs
+++ b/src/detours/statik.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::{Function, GenericDetour};
+use std::marker::Tuple;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::{mem, ptr};
 
@@ -104,6 +105,7 @@ impl<T: Function> StaticDetour<T> {
   pub unsafe fn initialize<D>(&self, target: T, closure: D) -> Result<&Self>
   where
     D: Fn<T::Arguments, Output = T::Output> + Send + 'static,
+    T::Arguments: Tuple,
   {
     let mut detour = Box::new(GenericDetour::new(target, self.ffi)?);
     if self
@@ -155,6 +157,7 @@ impl<T: Function> StaticDetour<T> {
   pub fn set_detour<C>(&self, closure: C)
   where
     C: Fn<T::Arguments, Output = T::Output> + Send + 'static,
+    T::Arguments: Tuple,
   {
     let previous = self
       .closure
@@ -175,7 +178,10 @@ impl<T: Function> StaticDetour<T> {
 
   /// Returns a transient reference to the active detour.
   #[doc(hidden)]
-  pub fn __detour(&self) -> &dyn Fn<T::Arguments, Output = T::Output> {
+  pub fn __detour(&self) -> &dyn Fn<T::Arguments, Output = T::Output>
+  where
+    T::Arguments: Tuple,
+  {
     // TODO: This is not 100% thread-safe in case the thread is stopped
     unsafe { self.closure.load(Ordering::SeqCst).as_ref() }
       .ok_or(Error::NotInitialized)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
   all(feature = "nightly", test),
   feature(naked_functions, core_intrinsics, asm)
 )]
+#![feature(tuple_trait)]
 
 //! A cross-platform detour library written in Rust.
 //!


### PR DESCRIPTION
In nightly, the compiler complains about:
```rust
error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> C:\Users\[redacted]\.cargo\registry\src\index.crates.io-6f17d22bba15001f\detour-0.8.1\src\detours\statik.rs:106:8
    |
106 |     D: Fn<T::Arguments, Output = T::Output> + Send + 'static,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `<T as Function>::Arguments`
    |
note: required by a bound in `Fn`
   --> C:\Users\[redacted]\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib/rustlib/src/rust\library\core\src\ops\function.rs:76:20
    |
76  | pub trait Fn<Args: Tuple>: FnMut<Args> {
    |                    ^^^^^ required by this bound in `Fn`
help: consider further restricting the associated type
    |
106 |     D: Fn<T::Arguments, Output = T::Output> + Send + 'static, <T as Function>::Arguments: Tuple
    |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The rust core lib's Fn trait was updated to constrain Args to have the Tuple trait.
This PR follows the suggestions of the compiler and fixes the issue by adding a bound to T::Arguments where it must also have Tuple.