### PR TITLE
fix missing Tuple trait

### DIFF
--- a/src/detours/statik.rs
+++ b/src/detours/statik.rs
@@ -104,6 +104,7 @@ impl<T: Function> StaticDetour<T> {
   pub unsafe fn initialize<D>(&self, target: T, closure: D) -> Result<&Self>
   where
     D: Fn<T::Arguments, Output = T::Output> + Send + 'static,
+    <T as crate::traits::Function>::Arguments: std::marker::Tuple,
   {
     let mut detour = Box::new(GenericDetour::new(target, self.ffi)?);
     if self
@@ -155,6 +156,7 @@ impl<T: Function> StaticDetour<T> {
   pub fn set_detour<C>(&self, closure: C)
   where
     C: Fn<T::Arguments, Output = T::Output> + Send + 'static,
+    <T as crate::traits::Function>::Arguments: std::marker::Tuple,
   {
     let previous = self
       .closure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![recursion_limit = "1024"]
 #![cfg_attr(
   feature = "nightly",
-  feature(const_fn_trait_bound, unboxed_closures, abi_thiscall)
+  feature(tuple_trait, const_fn_trait_bound, unboxed_closures, abi_thiscall)
 )]
 #![cfg_attr(
   all(feature = "nightly", test),


### PR DESCRIPTION
Fix the error message: ``error[E0059]: type parameter to bare `Fn` trait must be a tuple``